### PR TITLE
Changes in WP 4.2 breaking aspects of Sensei admin

### DIFF
--- a/classes/class-woothemes-sensei-analysis-course.php
+++ b/classes/class-woothemes-sensei-analysis-course.php
@@ -34,7 +34,6 @@ class WooThemes_Sensei_Analysis_Course_List_Table extends WooThemes_Sensei_List_
 	public $total_lessons;
 	public $user_ids;
 	public $view = 'lesson';
-	public $csv_output = false;
 	public $page_slug = 'sensei_analysis';
 
 	/**

--- a/classes/class-woothemes-sensei-analysis-lesson.php
+++ b/classes/class-woothemes-sensei-analysis-lesson.php
@@ -30,7 +30,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 class WooThemes_Sensei_Analysis_Lesson_List_Table extends WooThemes_Sensei_List_Table {
 	public $lesson_id;
 	public $course_id;
-	public $csv_output = false;
 	public $page_slug = 'sensei_analysis';
 
 	/**

--- a/classes/class-woothemes-sensei-analysis-overview.php
+++ b/classes/class-woothemes-sensei-analysis-overview.php
@@ -32,7 +32,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 class WooThemes_Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 	public $type;
-	public $csv_output = false;
 	public $page_slug = 'sensei_analysis';
 
 	/**

--- a/classes/class-woothemes-sensei-analysis-user-profile.php
+++ b/classes/class-woothemes-sensei-analysis-user-profile.php
@@ -29,7 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 class WooThemes_Sensei_Analysis_User_Profile_List_Table extends WooThemes_Sensei_List_Table {
 	public $user_id;
-	public $csv_output = false;
 	public $page_slug = 'sensei_analysis';
 
 	/**

--- a/classes/class-woothemes-sensei-learners-main.php
+++ b/classes/class-woothemes-sensei-learners-main.php
@@ -32,13 +32,6 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 	public $lesson_id = 0;
 	public $view = 'courses';
 	public $page_slug = 'sensei_learners';
-	/**
-	 * @var int $total_items
-	 *
-	 * Used for storing the total number of items available for the given query
-	 * also used for generating the pagination.
-	 */
-	protected $total_items  =  0;
 
 	/**
 	 * Constructor

--- a/classes/class-woothemes-sensei-list-table.php
+++ b/classes/class-woothemes-sensei-list-table.php
@@ -31,6 +31,15 @@ class WooThemes_Sensei_List_Table extends WP_List_Table {
 	public $token;
 
 	/**
+	 * Used for storing the total number of items available for the given query
+	 * also used for generating the pagination.
+	 *
+	 * @var int $total_items
+	 * @access public
+	 */
+	public $total_items = 0;
+
+	/**
 	 * Constructor
 	 * @since  1.2.0
 	 * @return  void

--- a/classes/class-woothemes-sensei-list-table.php
+++ b/classes/class-woothemes-sensei-list-table.php
@@ -31,6 +31,14 @@ class WooThemes_Sensei_List_Table extends WP_List_Table {
 	public $token;
 
 	/**
+	 * Used for indicating if the output is for csv or not
+	 *
+	 * @var bool $csv_output
+	 * @access public
+	 */
+	public $csv_output = false;
+
+	/**
 	 * Used for storing the total number of items available for the given query
 	 * also used for generating the pagination.
 	 *

--- a/classes/class-woothemes-sensei-list-table.php
+++ b/classes/class-woothemes-sensei-list-table.php
@@ -39,6 +39,14 @@ class WooThemes_Sensei_List_Table extends WP_List_Table {
 	public $csv_output = false;
 
 	/**
+	 * Used for storing the string of a search for passing between functions
+	 *
+	 * @var string $search
+	 * @access public
+	 */
+	public $search = false;
+
+	/**
 	 * Used for storing the total number of items available for the given query
 	 * also used for generating the pagination.
 	 *


### PR DESCRIPTION
Fixes #866 and #853 

Specifically the change in https://core.trac.wordpress.org/changeset/31146 causing object variables not defined to be ignored. This meant pagination broke (in most places), search broke, and csv output didn't universally work.