### PR TITLE
Add filters for the "with_front" property of the rewrite rules

### DIFF
--- a/classes/class-woothemes-sensei-posttypes.php
+++ b/classes/class-woothemes-sensei-posttypes.php
@@ -118,7 +118,16 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_menu' => true,
 		    'show_in_admin_bar' => true,
 		    'query_var' => true,
-		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url base', 'woothemes-sensei' ) ) ) , 'with_front' => true, 'feeds' => true, 'pages' => true ),
+            /**
+             * sensei_rewrite_course_with_front
+             *
+             * Allows for the "with_front" property of the rewrite rules for the course post type to be modified.
+             *
+             * @since 1.9.0
+             *
+             * @param bool $sensei_rewrite_course_with_front
+             */
+		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url base', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_course_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'course',
 		    'has_archive' => true,
@@ -155,7 +164,16 @@ class WooThemes_Sensei_PostTypes {
 		    'show_ui' => true,
 		    'show_in_menu' => true,
 		    'query_var' => true,
-		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => true, 'feeds' => true, 'pages' => true ),
+            /**
+             * sensei_rewrite_lesson_with_front
+             *
+             * Allows for the "with_front" property of the rewrite rules for the lesson post type to be modified.
+             *
+             * @since 1.9.0
+             *
+             * @param bool $sensei_rewrite_lesson_with_front
+             */
+		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_lesson_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'lesson',
 		    'has_archive' => true,
@@ -185,7 +203,16 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => true,
 		    'exclude_from_search' => true,
-		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_quiz_slug', _x( 'quiz', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => true, 'feeds' => true, 'pages' => true ),
+            /**
+             * sensei_rewrite_quiz_with_front
+             *
+             * Allows for the "with_front" property of the rewrite rules for the quiz post type to be modified.
+             *
+             * @since 1.9.0
+             *
+             * @param bool $sensei_rewrite_quiz_with_front
+             */
+		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_quiz_slug', _x( 'quiz', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_quiz_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'quiz',
 		    'has_archive' => false,
@@ -214,7 +241,16 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => true,
 		    'exclude_from_search' => true,
-		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_question_slug', _x( 'question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => true, 'feeds' => true, 'pages' => true ),
+            /**
+             * sensei_rewrite_question_with_front
+             *
+             * Allows for the "with_front" property of the rewrite rules for the question post type to be modified.
+             *
+             * @since 1.9.0
+             *
+             * @param bool $sensei_rewrite_question_with_front
+             */
+		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_question_slug', _x( 'question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_question_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'question',
 		    'has_archive' => true,
@@ -242,7 +278,16 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => false,
 		    'exclude_from_search' => true,
-		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_multiple_question_slug', _x( 'multiple_question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => false, 'feeds' => false, 'pages' => false ),
+            /**
+             * sensei_rewrite_multiple_question_with_front
+             *
+             * Allows for the "with_front" property of the rewrite rules for the multiple question post type to be modified.
+             *
+             * @since 1.9.0
+             *
+             * @param bool $sensei_rewrite_multiple_question_with_front
+             */
+		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_multiple_question_slug', _x( 'multiple_question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_multiple_question_with_front', false ), 'feeds' => false, 'pages' => false ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'question',
 		    'has_archive' => false,
@@ -273,7 +318,16 @@ class WooThemes_Sensei_PostTypes {
 			    'show_in_nav_menus' => true,
 			    'query_var' => true,
 			    'exclude_from_search' => true,
-			    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_messages_slug', _x( 'messages', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => false, 'feeds' => false, 'pages' => true ),
+                /**
+                 * sensei_rewrite_message_with_front
+                 *
+                 * Allows for the "with_front" property of the rewrite rules for the message post type to be modified.
+                 *
+                 * @since 1.9.0
+                 *
+                 * @param bool $sensei_rewrite_message_with_front
+                 */
+			    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_messages_slug', _x( 'messages', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_message_with_front', false ), 'feeds' => false, 'pages' => true ),
 			    'map_meta_cap' => true,
 			    'capability_type' => 'question',
 			    'has_archive' => true,

--- a/classes/class-woothemes-sensei-posttypes.php
+++ b/classes/class-woothemes-sensei-posttypes.php
@@ -119,7 +119,7 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_admin_bar' => true,
 		    'query_var' => true,
             /**
-             * sensei_rewrite_course_with_front
+             * "with_front" property of rewrite behavior for courses.
              *
              * Allows for the "with_front" property of the rewrite rules for the course post type to be modified.
              *
@@ -165,7 +165,7 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_menu' => true,
 		    'query_var' => true,
             /**
-             * sensei_rewrite_lesson_with_front
+             * "with_front" property of rewrite behavior for lessons.
              *
              * Allows for the "with_front" property of the rewrite rules for the lesson post type to be modified.
              *
@@ -204,7 +204,7 @@ class WooThemes_Sensei_PostTypes {
 		    'query_var' => true,
 		    'exclude_from_search' => true,
             /**
-             * sensei_rewrite_quiz_with_front
+             * "with_front" property of rewrite behavior for quizzes.
              *
              * Allows for the "with_front" property of the rewrite rules for the quiz post type to be modified.
              *
@@ -242,7 +242,7 @@ class WooThemes_Sensei_PostTypes {
 		    'query_var' => true,
 		    'exclude_from_search' => true,
             /**
-             * sensei_rewrite_question_with_front
+             * "with_front" property of rewrite behavior for questions.
              *
              * Allows for the "with_front" property of the rewrite rules for the question post type to be modified.
              *
@@ -279,7 +279,7 @@ class WooThemes_Sensei_PostTypes {
 		    'query_var' => false,
 		    'exclude_from_search' => true,
             /**
-             * sensei_rewrite_multiple_question_with_front
+             * "with_front" property of rewrite behavior for multiple questions.
              *
              * Allows for the "with_front" property of the rewrite rules for the multiple question post type to be modified.
              *
@@ -319,7 +319,7 @@ class WooThemes_Sensei_PostTypes {
 			    'query_var' => true,
 			    'exclude_from_search' => true,
                 /**
-                 * sensei_rewrite_message_with_front
+                 * "with_front" property of rewrite behavior for messages.
                  *
                  * Allows for the "with_front" property of the rewrite rules for the message post type to be modified.
                  *

--- a/classes/class-woothemes-sensei-posttypes.php
+++ b/classes/class-woothemes-sensei-posttypes.php
@@ -118,15 +118,15 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_menu' => true,
 		    'show_in_admin_bar' => true,
 		    'query_var' => true,
-            /**
-             * "with_front" property of rewrite behavior for courses.
-             *
-             * Allows for the "with_front" property of the rewrite rules for the course post type to be modified.
-             *
-             * @since 1.9.0
-             *
-             * @param bool $sensei_rewrite_course_with_front
-             */
+		    /**
+		     * "with_front" property of rewrite behavior for courses.
+		     *
+		     * Allows for the "with_front" property of the rewrite rules for the course post type to be modified.
+		     *
+		     * @since 1.9.0
+		     *
+		     * @param bool $sensei_rewrite_course_with_front
+		     */
 		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url base', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_course_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'course',
@@ -164,15 +164,15 @@ class WooThemes_Sensei_PostTypes {
 		    'show_ui' => true,
 		    'show_in_menu' => true,
 		    'query_var' => true,
-            /**
-             * "with_front" property of rewrite behavior for lessons.
-             *
-             * Allows for the "with_front" property of the rewrite rules for the lesson post type to be modified.
-             *
-             * @since 1.9.0
-             *
-             * @param bool $sensei_rewrite_lesson_with_front
-             */
+		    /**
+		     * "with_front" property of rewrite behavior for lessons.
+		     *
+		     * Allows for the "with_front" property of the rewrite rules for the lesson post type to be modified.
+		     *
+		     * @since 1.9.0
+		     *
+		     * @param bool $sensei_rewrite_lesson_with_front
+		     */
 		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_lesson_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'lesson',
@@ -203,15 +203,15 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => true,
 		    'exclude_from_search' => true,
-            /**
-             * "with_front" property of rewrite behavior for quizzes.
-             *
-             * Allows for the "with_front" property of the rewrite rules for the quiz post type to be modified.
-             *
-             * @since 1.9.0
-             *
-             * @param bool $sensei_rewrite_quiz_with_front
-             */
+		    /**
+		     * "with_front" property of rewrite behavior for quizzes.
+		     *
+		     * Allows for the "with_front" property of the rewrite rules for the quiz post type to be modified.
+		     *
+		     * @since 1.9.0
+		     *
+		     * @param bool $sensei_rewrite_quiz_with_front
+		     */
 		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_quiz_slug', _x( 'quiz', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_quiz_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'quiz',
@@ -241,15 +241,15 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => true,
 		    'exclude_from_search' => true,
-            /**
-             * "with_front" property of rewrite behavior for questions.
-             *
-             * Allows for the "with_front" property of the rewrite rules for the question post type to be modified.
-             *
-             * @since 1.9.0
-             *
-             * @param bool $sensei_rewrite_question_with_front
-             */
+		    /**
+		     * "with_front" property of rewrite behavior for questions.
+		     *
+		     * Allows for the "with_front" property of the rewrite rules for the question post type to be modified.
+		     *
+		     * @since 1.9.0
+		     *
+		     * @param bool $sensei_rewrite_question_with_front
+		     */
 		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_question_slug', _x( 'question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_question_with_front', true ), 'feeds' => true, 'pages' => true ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'question',
@@ -278,15 +278,15 @@ class WooThemes_Sensei_PostTypes {
 		    'show_in_nav_menus' => false,
 		    'query_var' => false,
 		    'exclude_from_search' => true,
-            /**
-             * "with_front" property of rewrite behavior for multiple questions.
-             *
-             * Allows for the "with_front" property of the rewrite rules for the multiple question post type to be modified.
-             *
-             * @since 1.9.0
-             *
-             * @param bool $sensei_rewrite_multiple_question_with_front
-             */
+		    /**
+		     * "with_front" property of rewrite behavior for multiple questions.
+		     *
+		     * Allows for the "with_front" property of the rewrite rules for the multiple question post type to be modified.
+		     *
+		     * @since 1.9.0
+		     *
+		     * @param bool $sensei_rewrite_multiple_question_with_front
+		     */
 		    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_multiple_question_slug', _x( 'multiple_question', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_multiple_question_with_front', false ), 'feeds' => false, 'pages' => false ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'question',
@@ -318,15 +318,15 @@ class WooThemes_Sensei_PostTypes {
 			    'show_in_nav_menus' => true,
 			    'query_var' => true,
 			    'exclude_from_search' => true,
-                /**
-                 * "with_front" property of rewrite behavior for messages.
-                 *
-                 * Allows for the "with_front" property of the rewrite rules for the message post type to be modified.
-                 *
-                 * @since 1.9.0
-                 *
-                 * @param bool $sensei_rewrite_message_with_front
-                 */
+				/**
+				 * "with_front" property of rewrite behavior for messages.
+				 *
+				 * Allows for the "with_front" property of the rewrite rules for the message post type to be modified.
+				 *
+				 * @since 1.9.0
+				 *
+				 * @param bool $sensei_rewrite_message_with_front
+				 */
 			    'rewrite' => array( 'slug' => esc_attr( apply_filters( 'sensei_messages_slug', _x( 'messages', 'post type single slug', 'woothemes-sensei' ) ) ) , 'with_front' => apply_filters( 'sensei_rewrite_message_with_front', false ), 'feeds' => false, 'pages' => true ),
 			    'map_meta_cap' => true,
 			    'capability_type' => 'question',


### PR DESCRIPTION
Allows for developers to better customize their URLs. In my case, my permalink structure is a hardcoded "/blog/%POSTNAME%", meaning that by default Sensei will create URLs like "/blog/course/foo-bar"-- not ideal. However, by flipping "with_front" to off, Sensei correctly uses the URL pattern "/course/foo-bar" while still allowing me to maintain my "/blog/%POSTNAME%" URLs.

Replaces #963 as requested, and addresses issue #964.