### PR TITLE
When id is not a product, soft return.

### DIFF
--- a/templates/woocommerce/add-to-cart.php
+++ b/templates/woocommerce/add-to-cart.php
@@ -25,7 +25,7 @@ if ( WooThemes_Sensei_Utils::sensei_customer_bought_product( $current_user->user
     if ( 0 < $wc_post_id ) {
         // Get the product
         $product = $woothemes_sensei->sensei_get_woocommerce_product_object( $wc_post_id );
-        if ( ! isset ( $product ) || ! is_object( $product ) ) exit;
+        if ( ! isset ( $product ) || ! is_object( $product ) ) return;
         if ( $product->is_purchasable() ) {
             // Check Product Availability
             $availability = $product->get_availability();


### PR DESCRIPTION
If id of the Woocommerce product to which sensei's product connected is no longer returns, template hard exits. Suggest just return the function. 