### PR TITLE
Show courses that are other statuses in the admin lesson filter

### DIFF
--- a/includes/class-woothemes-sensei-admin.php
+++ b/includes/class-woothemes-sensei-admin.php
@@ -672,6 +672,7 @@ class WooThemes_Sensei_Admin {
 
 			$args = array(
 				'post_type' => 'course',
+				'post_status' => array('publish', 'pending', 'draft', 'future', 'private'),
 				'posts_per_page' => -1,
 				'suppress_filters' => 0,
 				'orderby' => 'menu_order date',


### PR DESCRIPTION
Shows courses that are published, pending, drafts, published in the future, or private in the filter list. This is desirable because in the lesson view, you can *see* the lessons that belong to these courses but you can't actually select them as filters.

Addresses #997