### PR TITLE
Fixed teachers shortcode not listing teachers who have not set a first and last name

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-teachers.php
+++ b/includes/shortcodes/class-sensei-shortcode-teachers.php
@@ -231,8 +231,13 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
      */
     public function get_user_public_name( $user ){
 
-        $user_public_name = $user->first_name . ' ' . $user->last_name;
-        if( empty( $user_public_name ) ){
+        if (!empty($user->first_name) or !empty($user->last_name)) {
+
+            $user_public_name = $user->first_name . ' ' . $user->last_name;
+
+        }
+
+        else {
 
             $user_public_name = $user->display_name;
 

--- a/includes/shortcodes/class-sensei-shortcode-teachers.php
+++ b/includes/shortcodes/class-sensei-shortcode-teachers.php
@@ -231,7 +231,7 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
      */
     public function get_user_public_name( $user ){
 
-        if (!empty($user->first_name) or !empty($user->last_name)) {
+        if (!empty($user->first_name) && !empty($user->last_name)) {
 
             $user_public_name = $user->first_name . ' ' . $user->last_name;
 


### PR DESCRIPTION
Fixed #1000 - teachers shortcode not listing teacher if `$user->first_name` or `$user->last_name` are not set. 

However, in `get_user_public_name()`, if `$user->first_name` and `$user->last_name` are set, we ignore `$user->display_name` which each user sets in their Profile under the 'Display name publicly as' field.

<img width="605" alt="dr2anp5hug-2000x2000" src="https://cloud.githubusercontent.com/assets/10125810/8831209/6b7ea4c8-30be-11e5-99a4-e35a3a11af29.png">

In the above scenario, for example, the Teacher's 'Nickname' will not be displayed, even though they have chosen it in 'Display name publicly as'. Instead, we'll be using 'Firstname Lastname'.

Should we be doing this? It seems a little counter-intuitive.

(Mad props to @danjjohnson and @bryceadams for walking me through the PR process!)