### PR TITLE
Fixed teachers shortcode breaking without attributes

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-teachers.php
+++ b/includes/shortcodes/class-sensei-shortcode-teachers.php
@@ -198,24 +198,28 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
         // backup
         $users_ids = array();
-        foreach( $users as $user_id_or_username ){
 
-            if( ! is_numeric( $user_id_or_username ) ){
+        if ( is_array($users) ) {
 
-                $user_name = $user_id_or_username;
-                $user = get_user_by( 'login', $user_name  );
+            foreach ($users as $user_id_or_username) {
 
-                if( is_a( $user, 'WP_User' ) ){
-                  $users_ids[] = $user->ID;
+                if (!is_numeric($user_id_or_username)) {
+
+                    $user_name = $user_id_or_username;
+                    $user = get_user_by('login', $user_name);
+
+                    if (is_a($user, 'WP_User')) {
+                        $users_ids[] = $user->ID;
+                    }
+
+                } else {
+
+                    $user_id = $user_id_or_username;
+                    $users_ids[] = $user_id;
+
                 }
 
-            }else{
-
-                $user_id = $user_id_or_username;
-                $users_ids[] = $user_id;
-
             }
-
         }
 
         return $users_ids;


### PR DESCRIPTION
Fixed #1001 - teachers shortcode breaking unless both `include=""` and `exclude=""` are passed to it.

We check if `$users` is an array so that we don't pass a non-array to the `foreach()` loop, breaking it.