### PR TITLE
Do not show paid course content, regardless if "require login to view content" is disabled

### DIFF
--- a/templates/content-single-course.php
+++ b/templates/content-single-course.php
@@ -51,7 +51,18 @@ if ( ( isset( $woothemes_sensei->settings->settings['access_permission'] ) && ! 
                 ?>
 
                 <section class="entry fix">
-                	<?php if ( ( is_user_logged_in() && $is_user_taking_course ) || $access_permission || 'full' == $woothemes_sensei->settings->settings[ 'course_single_content_display' ] ) { the_content(); } else { echo '<p class="course-excerpt">' . $post->post_excerpt . '</p>'; } ?>
+									<?php
+									if(WooThemes_Sensei_Utils::sensei_is_woocommerce_activated()) {
+										$wc_post_id = get_post_meta( $post->ID, '_course_woocommerce_product', true );
+										$product = $woothemes_sensei->sensei_get_woocommerce_product_object( $wc_post_id );
+
+										$is_product = isset ( $product ) && is_object ( $product );
+									} else {
+										$is_product = false;
+									}
+									?>
+
+                	<?php if ( ( is_user_logged_in() && $is_user_taking_course ) || ($access_permission && !$is_product) || 'full' == $woothemes_sensei->settings->settings[ 'course_single_content_display' ] ) { the_content(); } else { echo '<p class="course-excerpt">' . $post->post_excerpt . '</p>'; } ?>
                 </section>
 
                 <?php do_action( 'sensei_course_single_lessons' ); ?>

--- a/templates/content-single-lesson.php
+++ b/templates/content-single-lesson.php
@@ -15,7 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  // Content Access Permissions
  $access_permission = false;
  if ( ( isset( $woothemes_sensei->settings->settings['access_permission'] ) && ! $woothemes_sensei->settings->settings['access_permission'] ) || sensei_all_access() ) {
- 	$access_permission = true;
+ 	if(WooThemes_Sensei_Utils::sensei_is_woocommerce_activated()) {
+    $course_id = get_post_meta( $post->ID, '_lesson_course', true );
+    $wc_post_id = get_post_meta( $course_id, '_course_woocommerce_product', true );
+    $product = $woothemes_sensei->sensei_get_woocommerce_product_object( $wc_post_id );
+
+    $access_permission = ! ( isset ( $product ) && is_object ( $product ) );
+  }
  } // End If Statement
 ?>
         	<article <?php post_class( array( 'lesson', 'post' ) ); ?>>


### PR DESCRIPTION
Addresses #1012 by always requiring a user to login if they are trying to view paid content. Otherwise, disabling the "Users must be logged in to view Course and Lesson content" option will allow for all *free* content to be viewable without logging in.

The current danger of merging this is that it changes the behavior of this option, but I think this is a more logical default...