### PR TITLE
Adding courses on purchase of Variable products.

### DIFF
--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -1544,56 +1544,59 @@ class WooThemes_Sensei_Frontend {
 			return;
 		}
 
-		$order_items = $order->get_items();
-
 		$messages = array();
 
-		foreach ( $order_items as $item ) {
+		foreach ( $order->get_items() as $item ) {
 
-            if ( $item['product_id'] > 0 ) {
+			if ( isset( $item['variation_id'] ) && ( 0 < $item['variation_id'] ) ) {
 
-				$user_id = get_post_meta( $order_id, '_customer_user', true );
+				// If item has variation_id then its a variation of the product
+				$item_id = $item['variation_id'];
 
-				if( $user_id ) {
+			} else {
 
-					// Get all courses for product
-					$args = array(
-						'posts_per_page' => -1,
-						'post_type' => 'course',
-						'meta_query' => array(
-							array(
-								'key' => '_course_woocommerce_product',
-								'value' => $item['product_id']
-							)
-						),
-						'orderby' => 'menu_order date',
-						'order' => 'ASC',
-					);
-					$courses = get_posts( $args );
+				//If not its real product set its id to item_id
+				$item_id = $item['product_id'];
 
-					if( $courses && count( $courses ) > 0 ) {
+			} // End If Statement
 
-						echo ' <p><div id= "message" class="updated fade woocommerce-info" >';
-						foreach( $courses as $course ) {
+			$user_id = get_post_meta( $order->id, '_customer_user', true );
 
-							$title = $course->post_title;
-							$permalink = get_permalink( $course->ID );
+			if( $user_id ) {
 
-							echo '<strong>'. sprintf( __( 'View course: %1$s', 'woothemes-sensei' ), '<a href="' . esc_url( $permalink ) . '" >' . $title . '</a> ' ). '</strong> <br/>';
+				// Get all courses for product
+				$args = array(
+					'posts_per_page' => -1,
+					'post_type' => 'course',
+					'meta_query' => array(
+						array(
+							'key' => '_course_woocommerce_product',
+							'value' => $item_id
+						)
+					),
+					'orderby' => 'menu_order date',
+					'order' => 'ASC',
+				);
+				$courses = get_posts( $args );
 
-							$update_course = $woothemes_sensei->woocommerce_course_update( $course->ID  );
+				if( $courses && count( $courses ) > 0 ) {
 
-						} // end for each
+					echo ' <p><div id= "message" class="updated fade woocommerce-info" >';
+					foreach( $courses as $course ) {
 
-						// close the message div
-						echo ' </div></p>';
+						$title = $course->post_title;
+						$permalink = get_permalink( $course->ID );
 
-					}// end if $courses check
-				}
+						echo '<strong>'. sprintf( __( 'View course: %1$s', 'woothemes-sensei' ), '<a href="' . esc_url( $permalink ) . '" >' . $title . '</a> ' ). '</strong> <br/>';
+
+					} // end for each
+
+					// close the message div
+					echo ' </div></p>';
+
+				}// end if $courses check
 			}
 		}
-		// show the links to the course
-
 	} // end course_link_order_form
 
 	/**
@@ -1640,8 +1643,14 @@ class WooThemes_Sensei_Frontend {
 
 					$items = $order->get_items();
 					foreach( $items as $item ) {
-						$product_id = $item['product_id'];
-						$product_ids[] = $product_id;
+	                    if (isset($item['variation_id']) && $item['variation_id'] > 0) {
+	                        $item_id = $item['variation_id'];
+							$product_type = 'variation';
+	                    } else {
+	                        $item_id = $item['product_id'];
+	                    }
+
+						$product_ids[] = $item_id;
 					}
 
 					$order_ids[] = $post_id;

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -1488,8 +1488,15 @@ class WooThemes_Sensei_Frontend {
 		$order = new WC_Order( $order_id );
 
 		foreach ( $order->get_items() as $item ) {
+			if ( isset( $item['variation_id'] ) && ( 0 < $item['variation_id'] ) ) {
+				// If item has variation_id then its a variation of the product
+				$item_id = $item['variation_id'];
+			} else {
+				// Than its real product set it's id to item_id
+				$item_id = $item['product_id'];
+			} 
 
-            if ( $item['product_id'] > 0 ) {
+            if ( $item_id > 0 ) {
 
 				$user_id = get_post_meta( $order_id, '_customer_user', true );
 
@@ -1502,7 +1509,7 @@ class WooThemes_Sensei_Frontend {
 						'meta_query' => array(
 							array(
 								'key' => '_course_woocommerce_product',
-								'value' => $item['product_id']
+								'value' => $item_id
 							)
 						),
 						'orderby' => 'menu_order date',
@@ -1643,18 +1650,17 @@ class WooThemes_Sensei_Frontend {
 
 					$items = $order->get_items();
 					foreach( $items as $item ) {
-	                    if (isset($item['variation_id']) && $item['variation_id'] > 0) {
-	                        $item_id = $item['variation_id'];
-							$product_type = 'variation';
-	                    } else {
-	                        $item_id = $item['product_id'];
-	                    }
+                                            if (isset($item['variation_id']) && $item['variation_id'] > 0) {
+                                                $item_id = $item['variation_id'];
+                                                $product_type = 'variation';
+                                            } else {
+                                                $item_id = $item['product_id'];
+                                            }
 
-						$product_ids[] = $item_id;
-					}
+                                            $product_ids[] = $item_id;
+                                            }
 
 					$order_ids[] = $post_id;
-
 				}
 
 				if( count( $product_ids ) > 0 ) {
@@ -1759,7 +1765,7 @@ class WooThemes_Sensei_Frontend {
 
 				$items = $order->get_items();
 				foreach( $items as $item ) {
-					if( $item['product_id'] == $course_product_id ) {
+					if( $item['product_id']  == $course_product_id || $item['variation_id'] == $course_product_id ) {
 						WooThemes_Sensei_Utils::user_start_course( $user_id, $course_id );
 						return;
 					}

--- a/includes/class-woothemes-sensei-utils.php
+++ b/includes/class-woothemes-sensei-utils.php
@@ -434,7 +434,7 @@ class WooThemes_Sensei_Utils {
 
 		foreach ( $orders as $order_id ) {
 			$order = new WC_Order( $order_id->ID );
-			if ( $order->post_status == 'wc-completed' ) {
+			if ( $order->post_status == 'wc-completed' || $order->post_status == 'wc-processing' ) {
 				if ( 0 < sizeof( $order->get_items() ) ) {
 					foreach( $order->get_items() as $item ) {
 

--- a/includes/class-woothemes-sensei.php
+++ b/includes/class-woothemes-sensei.php
@@ -1170,9 +1170,19 @@ class WooThemes_Sensei {
 
         $messages = array();
 
-        foreach ( $order_items as $item ) {
+        //If object have items go through them all to find course
+        if ( 0 < sizeof( $order_items ) ) {
 
-            if ( $item['product_id'] > 0 ) {
+            foreach ( $order_items as $item ) {
+                $product_type = '';
+                if ( isset( $item['variation_id'] ) && ( 0 < $item['variation_id'] ) ) {
+                    // If item has variation_id then its from variation
+                    $item_id = $item['variation_id'];
+                    $product_type = 'variation';
+                } else {
+                    // If not its real product set its id to item_id
+                    $item_id = $item['product_id'];
+                } // End If Statement
 
                 $user_id = get_post_meta( $order_id, '_customer_user', true );
 
@@ -1185,7 +1195,7 @@ class WooThemes_Sensei {
                         'meta_query' => array(
                             array(
                                 'key' => '_course_woocommerce_product',
-                                'value' => $item['product_id']
+                                'value' => $item_id
                             )
                         ),
                         'orderby' => 'menu_order date',
@@ -1197,12 +1207,11 @@ class WooThemes_Sensei {
 
                         foreach( $courses as $course ) {
 
+                            echo '<h2>' . __( 'Course details', 'woothemes-sensei' ) . '</h2>';
+
                             $title = $course->post_title;
                             $permalink = get_permalink( $course->ID );
-
-                            echo '<h2>' . __( 'Course details', 'woothemes-sensei' ) . '</h2>';
                             echo '<p><strong>' . sprintf( __( 'View course: %1$s', 'woothemes-sensei' ), '</strong><a href="' . esc_url( $permalink ) . '">' . $title . '</a>' ) . '</p>';
-
                         }
                     }
                 }

--- a/includes/class-woothemes-sensei.php
+++ b/includes/class-woothemes-sensei.php
@@ -961,7 +961,7 @@ class WooThemes_Sensei {
                     } // End If Statement
                     $_product = $this->sensei_get_woocommerce_product_object( $item_id, $product_type );
                     // Get courses that use the WC product
-                    $courses = $this->post_types->course->get_product_courses( $_product->id );
+                    $courses = $this->post_types->course->get_product_courses( $item_id );               
                     // Loop and update those courses
                     foreach ( $courses as $course_item ) {
                         $update_course = $this->woocommerce_course_update( $course_item->ID, $order_user );


### PR DESCRIPTION
@danjjohnson 
Now working flawlessly adding courses purchased through Variations of the products.
Reason @dwainm had courses added to the user only after marking it complete because function sensei_customer_bought_product only ran on wc-complete status, which by default sensei no marks for any items. Only place where it marks completed is by default in Woocommerce if item is both virtual and downloadable. I would suggest to mark completed by sensei. 

Also it touches notifications to the email, and in thank you page.
Now removes user from course when variable product when order refunded or canceled.