### PR TITLE
Fix deprecated PHP 4 constructors

### DIFF
--- a/widgets/widget-woothemes-sensei-category-courses.php
+++ b/widgets/widget-woothemes-sensei-category-courses.php
@@ -50,7 +50,7 @@ class WooThemes_Sensei_Category_Courses_Widget extends WP_Widget {
 		$control_ops = array( 'width' => 250, 'height' => 350, 'id_base' => $this->woo_widget_idbase );
 
 		/* Create the widget. */
-		$this->WP_Widget( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**

--- a/widgets/widget-woothemes-sensei-course-categories.php
+++ b/widgets/widget-woothemes-sensei-course-categories.php
@@ -50,7 +50,7 @@ class WooThemes_Sensei_Course_Categories_Widget extends WP_Widget {
 		$control_ops = array( 'width' => 250, 'height' => 350, 'id_base' => $this->woo_widget_idbase );
 
 		/* Create the widget. */
-		$this->WP_Widget( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**

--- a/widgets/widget-woothemes-sensei-course-component.php
+++ b/widgets/widget-woothemes-sensei-course-component.php
@@ -62,7 +62,7 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 		$control_ops = array( 'width' => 250, 'height' => 350, 'id_base' => $this->woo_widget_idbase );
 
 		/* Create the widget. */
-		$this->WP_Widget( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**

--- a/widgets/widget-woothemes-sensei-lesson-component.php
+++ b/widgets/widget-woothemes-sensei-lesson-component.php
@@ -54,7 +54,7 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 		$control_ops = array( 'width' => 250, 'height' => 350, 'id_base' => $this->woo_widget_idbase );
 
 		/* Create the widget. */
-		$this->WP_Widget( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**


### PR DESCRIPTION
PHP 4 constructors are deprecated and will stop work https://wiki.php.net/rfc/remove_php4_constructors

Now WordPress 4.3 will throw errors for it too:
https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/

```
[29-Jul-2015 18:53:52 UTC] PHP Notice:  The called constructor method for WP_Widget is <strong>deprecated</strong> since version 4.3.0! Use <pre>__construct()</pre> instead. in /var/www/woocommerce-dev/wp-includes/functions.php on line 3457
[29-Jul-2015 18:53:52 UTC] PHP Notice:  The called constructor method for WP_Widget is <strong>deprecated</strong> since version 4.3.0! Use <pre>__construct()</pre> instead. in /var/www/woocommerce-dev/wp-includes/functions.php on line 3457
[29-Jul-2015 18:53:52 UTC] PHP Notice:  The called constructor method for WP_Widget is <strong>deprecated</strong> since version 4.3.0! Use <pre>__construct()</pre> instead. in /var/www/woocommerce-dev/wp-includes/functions.php on line 3457
[29-Jul-2015 18:53:52 UTC] PHP Notice:  The called constructor method for WP_Widget is <strong>deprecated</strong> since version 4.3.0! Use <pre>__construct()</pre> instead. in /var/www/woocommerce-dev/wp-includes/functions.php on line 3457
```