### PR TITLE
Use 'slug' field to get question-type, instead of 'name' field

### DIFF
--- a/includes/class-woothemes-sensei-lesson.php
+++ b/includes/class-woothemes-sensei-lesson.php
@@ -776,7 +776,7 @@ class WooThemes_Sensei_Lesson {
 				$question_id = $question->ID;
 
 				$question_type = '';
-				$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'names' ) );
+				$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'slugs' ) );
 				if ( isset( $question_types[0] ) && '' != $question_types[0] ) {
 					$question_type = $question_types[0];
 				} // End If Statement

--- a/includes/class-woothemes-sensei-lesson.php
+++ b/includes/class-woothemes-sensei-lesson.php
@@ -2104,7 +2104,7 @@ class WooThemes_Sensei_Lesson {
 
 			    	add_post_meta( $question_id, '_quiz_question_order' . $quiz_id, $quiz_id . '000' . $question_count );
 
-					$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'names' ) );
+					$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'slugs' ) );
 					$question_type = '';
 					if ( isset( $question_types[0] ) && '' != $question_types[0] ) {
 						$question_type = $question_types[0];

--- a/includes/class-woothemes-sensei-lesson.php
+++ b/includes/class-woothemes-sensei-lesson.php
@@ -1267,7 +1267,7 @@ class WooThemes_Sensei_Lesson {
 		if( $row % 2 ) { $existing_class = 'alternate'; }
 
 		$all_question_types = $woothemes_sensei->post_types->question->question_types();
-		$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'names' ) );
+		$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'slugs' ) );
 		$question_type = '';
 		if ( isset( $question_types[0] ) && '' != $question_types[0] ) {
 			$question_type = $question_types[0];

--- a/includes/class-woothemes-sensei-lesson.php
+++ b/includes/class-woothemes-sensei-lesson.php
@@ -1938,7 +1938,7 @@ class WooThemes_Sensei_Lesson {
 				$current_user = wp_get_current_user();
 				$question_data['post_author'] = $current_user->ID;
 				$question_id = $this->lesson_save_question( $question_data );
-				$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'names' ) );
+				$question_types = wp_get_post_terms( $question_id, 'question-type', array( 'fields' => 'slugs' ) );
 				$question_counter = 0;
 				$question_type = '';
 				if ( isset( $question_types[0] ) && '' != $question_types[0] ) {


### PR DESCRIPTION
This results in cleaner data being stored in `$question_types` here. 

Fixes #978, though there may be a better way to do this. The `name` column in the `wp_terms` table gets populated with values like "gap-fill (WooThemes)" though it's not yet clear how and when this happens (further testing required).

By assigning `$question_types` based on the `slug` field here, we're skipping the messy 'name' field and dealing with the cleaner slug data.