### PR TITLE
Show admin bar to users who can 'edit_courses'

### DIFF
--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -122,7 +122,10 @@ class WooThemes_Sensei_Frontend {
 		// Only show course & lesson excerpts in search results
 		add_filter( 'the_content', array( $this, 'sensei_search_results_excerpt' ) );
 
-		// Remove course from active courses if an order is cancelled or refunded
+        //Override WooCommerce filter and show admin bar to Teachers.
+        add_action( 'init', array( $this, 'sensei_show_admin_bar') );
+
+        // Remove course from active courses if an order is cancelled or refunded
 		add_action( 'woocommerce_order_status_processing_to_cancelled', array( $this, 'remove_active_course' ), 10, 1 );
 		add_action( 'woocommerce_order_status_completed_to_cancelled', array( $this, 'remove_active_course' ), 10, 1 );
 		add_action( 'woocommerce_order_status_on-hold_to_cancelled', array( $this, 'remove_active_course' ), 10, 1 );
@@ -143,6 +146,8 @@ class WooThemes_Sensei_Frontend {
 		add_action( 'pre_get_posts', array( $this, 'lesson_tag_archive_filter' ), 10, 1 );
 		add_filter( 'sensei_lessons_archive_text', array( $this, 'lesson_tag_archive_header' ) );
 		add_action( 'sensei_lesson_archive_header', array( $this, 'lesson_tag_archive_description' ), 11 );
+
+
 
 		// Hide Sensei activity comments from lesson and course pages
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
@@ -2019,5 +2024,24 @@ class WooThemes_Sensei_Frontend {
 			$woothemes_sensei->notices->add_notice( $message, 'alert');
 
 	}// end login_message_process
+
+
+    /**
+     * sensei_show_admin_bar(). override WooCommerce filter
+     * to show admin bar to Teachers as well.
+     *
+     * @return void redirect
+     *
+     */
+
+    public function sensei_show_admin_bar () {
+
+        if (current_user_can('edit_courses')) {
+
+            add_filter( 'woocommerce_disable_admin_bar', '__return_false', 10, 1);
+
+        }
+
+    }
 
 } // End Class

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -122,7 +122,7 @@ class WooThemes_Sensei_Frontend {
 		// Only show course & lesson excerpts in search results
 		add_filter( 'the_content', array( $this, 'sensei_search_results_excerpt' ) );
 
-        //Override WooCommerce filter and show admin bar to Teachers.
+        //Use WooCommerce filter to show admin bar to Teachers.
         add_action( 'init', array( $this, 'sensei_show_admin_bar') );
 
         // Remove course from active courses if an order is cancelled or refunded
@@ -2027,7 +2027,7 @@ class WooThemes_Sensei_Frontend {
 
 
     /**
-     * sensei_show_admin_bar(). override WooCommerce filter
+     * sensei_show_admin_bar(). Use WooCommerce filter
      * to show admin bar to Teachers as well.
      *
      * @return void redirect

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -147,8 +147,6 @@ class WooThemes_Sensei_Frontend {
 		add_filter( 'sensei_lessons_archive_text', array( $this, 'lesson_tag_archive_header' ) );
 		add_action( 'sensei_lesson_archive_header', array( $this, 'lesson_tag_archive_description' ), 11 );
 
-
-
 		// Hide Sensei activity comments from lesson and course pages
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
 	} // End __construct()


### PR DESCRIPTION
Fixes #1030 

WooCommerce by default disables the frontend admin bar for users who don't have the `edit_posts` capability. Here, we use the WooCommerce filter `woocommerce_disable_admin_bar` to show the frontend admin bar to Teachers (who have the `edit_courses` capability instead of the `edit_posts` capability`).