### PR TITLE
Use the `transition_post_status` action instead of `wp_insert_post`

### DIFF
--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -846,8 +846,7 @@ class Sensei_Teacher {
         $course_id = $post->ID;
 
         if( 'course' != get_post_type( $course_id ) || 'auto-draft' == get_post_status( $course_id )
-            || 'trash' == get_post_status( $course_id ) || 'draft' == $old_status && 'draft' == $new_status
-            || 'draft' == $old_status && 'pending' == $new_status) {
+            || 'trash' == get_post_status( $course_id ) || 'draft' == get_post_status( $course_id ) ) {
 
             return false;
 


### PR DESCRIPTION
Fixed #904. We now use the `transition_post_status` action instead of the `wp_insert_post` action to check whether we should send the admin a course creation email or not. This action is more flexible, and allows us to use better logic to decide if we email or not.

I have removed `remove_action()` because it does not seem to work here, perhaps due to the order in which these actions are fired.