### PR TITLE
Give teachers access to Comments menu page

### DIFF
--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1464,9 +1464,9 @@ class Sensei_Teacher {
 
     public function restrict_comment_moderation($clauses) {
 
-        global $current_user;
+        global $current_user, $pagenow;
 
-        if( current_user_can('teacher') ) {
+        if( current_user_can('teacher') && $pagenow == "edit-comments.php") {
 
             $clauses->query_vars['post_author'] = $current_user->ID;
         }

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1431,7 +1431,7 @@ class Sensei_Teacher {
 
         $user = wp_get_current_user();
 
-        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts')) {
+        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && apply_filters('sensei_restrict_posts_page', true )) {
 
             remove_menu_page('edit.php');
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -195,7 +195,6 @@ class Sensei_Teacher {
             'read_private_sensei_messages' => true,
 
             'edit_comment' => true,
-            'edit_posts' => true,
 
             // Group post type Todo: find out from Hugh
 
@@ -1432,7 +1431,7 @@ class Sensei_Teacher {
 
         $user = wp_get_current_user();
 
-        if ( in_array( 'teacher', (array) $user->roles ) ) {
+        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts')) {
 
             remove_menu_page('edit.php');
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1455,7 +1455,7 @@ class Sensei_Teacher {
      * Sensei_Teacher::restrict_comment_moderation()
      *
      * Restrict commendation moderation for teachers
-     * so they can only edit comments made to posts they own.
+     * so they can only moderate comments made to posts they own.
      *
      * @since 1.8.7
      * @access public

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1431,7 +1431,7 @@ class Sensei_Teacher {
 
         $user = wp_get_current_user();
 
-        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && apply_filters('sensei_restrict_posts_page', true )) {
+        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && apply_filters('sensei_restrict_posts_menu_page', true )) {
 
             remove_menu_page('edit.php');
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1431,6 +1431,14 @@ class Sensei_Teacher {
 
         $user = wp_get_current_user();
 
+        /**
+         * Filter the option to hide the Posts menu page.
+         *
+         * @since 1.8.7
+         *
+         * @param bool $restrict default true
+         */
+
         $restrict = apply_filters('sensei_restrict_posts_menu_page', true );
 
         if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && $restrict) {

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1431,7 +1431,9 @@ class Sensei_Teacher {
 
         $user = wp_get_current_user();
 
-        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && apply_filters('sensei_restrict_posts_menu_page', true )) {
+        $restrict = apply_filters('sensei_restrict_posts_menu_page', true );
+
+        if ( in_array( 'teacher', (array) $user->roles ) && !current_user_can('delete_posts') && $restrict) {
 
             remove_menu_page('edit.php');
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1440,9 +1440,7 @@ class Sensei_Teacher {
 
                 if ($typenow == '' || $typenow == 'post' || $typenow == 'page') {
 
-                    wp_redirect(admin_url());
-
-                    exit;
+                    wp_die('You do not have sufficient permissions to access this page.');
 
                 }
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1430,7 +1430,9 @@ class Sensei_Teacher {
 
         global $pagenow, $typenow;
 
-        if (current_user_can('teacher')) {
+        $user = wp_get_current_user();
+
+        if ( in_array( 'teacher', (array) $user->roles ) ) {
 
             remove_menu_page('edit.php');
 
@@ -1464,11 +1466,13 @@ class Sensei_Teacher {
 
     public function restrict_comment_moderation($clauses) {
 
-        global $current_user, $pagenow;
+        global $pagenow;
 
-        if( current_user_can('teacher') && $pagenow == "edit-comments.php") {
+        $user = wp_get_current_user();
 
-            $clauses->query_vars['post_author'] = $current_user->ID;
+        if( in_array( 'teacher', (array) $user->roles ) && $pagenow == "edit-comments.php") {
+
+            $clauses->query_vars['post_author'] = $user->ID;
         }
 
         return $clauses;


### PR DESCRIPTION
Gives teachers access to the Comments page while restricting access to the Posts menu page.

Fixes #1032 and replaces #1033, but I'm sure this can be optimised further, and I'd be happy to refine it based on feedback.

It definitely requires extensive testing, as there are a lot of screens / elements in play here.