### PR TITLE
Redirect teachers to admin_url() on login

### DIFF
--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -94,6 +94,10 @@ class Sensei_Teacher {
         // update lesson owner to course teacher when saved
         add_action( 'save_post',  array( $this, 'update_lesson_teacher' ) );
 
+        // If a Teacher logs in, redirect to /wp-admin/
+        add_filter( 'wp_login', array( $this, 'teacher_login_redirect') , 10, 2 );
+
+
     } // end __constructor()
 
     /**
@@ -1404,5 +1408,34 @@ class Sensei_Teacher {
         return $wp_query;
 
     } // end limit_teacher_edit_screen_post_types()
+
+
+    /**
+     * Sensei_Teacher::teacher_login_redirect
+     *
+     * Redirect teachers to /wp-admin/ after login
+     *
+     * @since 1.8.7
+     * @access public
+     * @param string $user_login
+     * @param object $user
+     * @return void
+     */
+
+    public function teacher_login_redirect( $user_login, $user  ) {
+
+        if ( isset( $user->roles ) && is_array( $user->roles ) ) {
+
+            if (user_can($user, 'edit_courses')) {
+
+                wp_redirect( admin_url(), 303 );
+
+                exit;
+
+            }
+        }
+
+    } // end teacher_login_redirect()
+
 
 } // End Class

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1424,17 +1424,25 @@ class Sensei_Teacher {
 
     public function teacher_login_redirect( $user_login, $user  ) {
 
+        var_dump($_POST['redirect']);
+
         if ( isset( $user->roles ) && is_array( $user->roles ) ) {
 
             if (user_can($user, 'edit_courses')) {
 
-                wp_redirect( admin_url(), 303 );
+                if (isset($_POST['redirect_to'])) {
 
-                exit;
+                    wp_redirect($_POST['redirect_to'], 303); exit;
 
+                } else {
+
+                    wp_redirect(admin_url(), 303);
+
+                    exit;
+
+                }
             }
         }
-
     } // end teacher_login_redirect()
 
 

--- a/classes/class-sensei-teacher.php
+++ b/classes/class-sensei-teacher.php
@@ -1424,25 +1424,23 @@ class Sensei_Teacher {
 
     public function teacher_login_redirect( $user_login, $user  ) {
 
-        var_dump($_POST['redirect']);
+        if (user_can($user, 'edit_courses')) {
 
-        if ( isset( $user->roles ) && is_array( $user->roles ) ) {
+            if (isset($_POST['redirect_to'])) {
 
-            if (user_can($user, 'edit_courses')) {
+                wp_redirect($_POST['redirect_to'], 303);
 
-                if (isset($_POST['redirect_to'])) {
+                exit;
 
-                    wp_redirect($_POST['redirect_to'], 303); exit;
+            } else {
 
-                } else {
+                wp_redirect(admin_url(), 303);
 
-                    wp_redirect(admin_url(), 303);
+                exit;
 
-                    exit;
-
-                }
             }
         }
+
     } // end teacher_login_redirect()
 
 


### PR DESCRIPTION
Fixes #972. Not sure if checking for the `edit_courses` cap is the cleanest way to do this, but it seemed best to tie this behaviour to the cap iself, rather than the role, as there could be custom roles that use the `edit_courses` cap as well.