### PR TITLE
Pass set values to Lesson Complete / Reset form handlers

### DIFF
--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -838,18 +838,18 @@ class WooThemes_Sensei_Frontend {
 	public function sensei_complete_lesson() {
 		global $post, $woothemes_sensei, $current_user;
 		// Handle Quiz Completion
-		if ( isset( $_POST['quiz_complete'] ) && wp_verify_nonce( $_POST[ 'woothemes_sensei_complete_lesson_noonce' ], 'woothemes_sensei_complete_lesson_noonce' ) ) {
+		if ( isset( $_POST['quiz_action'] ) && wp_verify_nonce( $_POST[ 'woothemes_sensei_complete_lesson_noonce' ], 'woothemes_sensei_complete_lesson_noonce' ) ) {
 
-			$sanitized_submit = esc_html( $_POST['quiz_complete'] );
+			$sanitized_submit = esc_html( $_POST['quiz_action'] );
 
 			switch ($sanitized_submit) {
-				case apply_filters( 'sensei_complete_lesson_text', __( 'Complete Lesson', 'woothemes-sensei' ) ):
+                case 'lesson-complete':
 
 					WooThemes_Sensei_Utils::sensei_start_lesson( $post->ID, $current_user->ID, $complete = true );
 
 					break;
 
-				case apply_filters( 'sensei_reset_lesson_text', __( 'Reset Lesson', 'woothemes-sensei' ) ):
+                case 'lesson-reset':
 
 					WooThemes_Sensei_Utils::sensei_remove_user_from_lesson( $post->ID, $current_user->ID );
 
@@ -985,7 +985,8 @@ class WooThemes_Sensei_Frontend {
 			?>
 			<form class="lesson_button_form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>#lesson_complete">
 	            <input type="hidden" name="<?php echo esc_attr( 'woothemes_sensei_complete_lesson_noonce' ); ?>" id="<?php echo esc_attr( 'woothemes_sensei_complete_lesson_noonce' ); ?>" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_lesson_noonce' ) ); ?>" />
-	            <span><input type="submit" name="quiz_complete" class="quiz-submit complete" value="<?php echo apply_filters( 'sensei_complete_lesson_text', __( 'Complete Lesson', 'woothemes-sensei' ) ); ?>"/></span>
+	            <input type="hidden" name="quiz_action" value="lesson-complete" />
+	            <span><input type="submit" name="quiz_complete" class="quiz-submit complete" value="<?php echo apply_filters( 'sensei_complete_lesson_text', __( 'Complete Lesson', 'woothemes-sensei' ) ); ?>"/></form></span>
 	        </form>
 			<?php
 		} // End If Statement
@@ -1007,7 +1008,8 @@ class WooThemes_Sensei_Frontend {
 		?>
 		<form method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
             <input type="hidden" name="<?php echo esc_attr( 'woothemes_sensei_complete_lesson_noonce' ); ?>" id="<?php echo esc_attr( 'woothemes_sensei_complete_lesson_noonce' ); ?>" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_lesson_noonce' ) ); ?>" />
-            <span><input type="submit" name="quiz_complete" class="quiz-submit reset" value="<?php echo apply_filters( 'sensei_reset_lesson_text', __( 'Reset Lesson', 'woothemes-sensei' ) ); ?>"/></span>
+            <input type="hidden" name="quiz_action" value="lesson-reset" />
+            <span><input type="submit" name="quiz_complete" class="quiz-submit reset" value="<?php echo apply_filters( 'sensei_reset_lesson_text', __( 'Reset Lesson', 'woothemes-sensei' ) ); ?>"/></form></span>
         </form>
 		<?php
 		} // End If Statement


### PR DESCRIPTION
Fixed #1063, where strings changed via translations would break the Lesson Complete / Reset form handlers.

We now pass the set values `lesson-complete` and `lesson-reset` in a hidden input field so the form handler can check for the same values every time, regardless of the text displayed in the submit button.