### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{md,txt,json,yml}]
+trim_trailing_whitespace = false
+
+[*.{json,yml}]
+insert_final_newline = false
+indent_size = 2
+tab_width = 2


### PR DESCRIPTION
This helps please follow some WordPress coding standards for indentation, line break format and so on.

People can just install a plugin from http://editorconfig.org/ and code editor/IDE will respect the params from `.editorconfig` file :)