### PR TITLE
Add 'edit_posts' cap to Teacher role

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -199,6 +199,7 @@ class Sensei_Teacher {
             'read_private_sensei_messages' => true,
 
             'edit_comment' => true,
+            'edit_posts' => true,
 
             // Group post type Todo: find out from Hugh
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -198,6 +198,11 @@ class Sensei_Teacher {
             'edit_private_sensei_messages' => true,
             'read_private_sensei_messages' => true,
 
+            // Comments -
+            // Necessary cap so Teachers can moderate comments
+            // on their own lessons. We restrict access to other
+            // post types in $this->restrict_posts_menu_page()
+
             'edit_posts' => true,
 
             // Group post type Todo: find out from Hugh

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -198,7 +198,6 @@ class Sensei_Teacher {
             'edit_private_sensei_messages' => true,
             'read_private_sensei_messages' => true,
 
-            'edit_comment' => true,
             'edit_posts' => true,
 
             // Group post type Todo: find out from Hugh


### PR DESCRIPTION
Partially fixes #1032 by allowing the Teacher role full access to the Comments menu item.