### PR TITLE
Load Sensei settings before setting up lesson CPT

### DIFF
--- a/includes/class-woothemes-sensei-settings-api.php
+++ b/includes/class-woothemes-sensei-settings-api.php
@@ -112,7 +112,7 @@ class WooThemes_Sensei_Settings_API {
 	public function setup_settings () {
 		add_action( 'admin_menu', array( $this, 'register_settings_screen' ), 60 );
 		add_action( 'admin_init', array( $this, 'settings_fields' ) );
-		add_action( 'wp_loaded', array( $this, 'general_init' ) );
+		add_action( 'init', array( $this, 'general_init' ) );
 	} // End setup_settings()
 
 	/**


### PR DESCRIPTION
Fixes #1087. 

We now run `woothemes-sensei-settings-api->general_init()` on `init` instead of `wp_loaded`. 

This is so that ` setup_lesson_post_type`, which we do on `init`, with a priority of `100`, runs after it, meaning that it can check for the `lesson_comments` setting, and find that it is enabled by default.

Tested this fix quite a bit to ensure nothing else breaks because of it, but it will require some additional testing as well.