### PR TITLE
Sort main query on custom taxonomy pages to pass posts in menu_order

### DIFF
--- a/includes/class-woothemes-sensei-course.php
+++ b/includes/class-woothemes-sensei-course.php
@@ -84,6 +84,9 @@ class WooThemes_Sensei_Course {
         // add the user status on the course to the markup as a class
         add_filter('post_class', array( __CLASS__ , 'add_course_user_status_class' ), 20, 3 );
 
+        // Sort the main query on custom taxonomy pages to pass posts in 'menu_order'
+        add_action('pre_get_posts', array ( $this, 'sensei_course_category_order_main_content' ) );
+
 	} // End __construct()
 
 	/**
@@ -2019,5 +2022,26 @@ class WooThemes_Sensei_Course {
         <?php  }// end if is user logged in
 
     }// end the_course_action_buttons
+
+    /**
+     * sensei_course_category_order_main_content function
+     *
+     * Sort the main query on custom taxonomy pages to pass posts in
+     * 'menu_order', because Sensei allows users to set the order of
+     * Courses under Course > Course Order.
+     *
+     * @since 1.9.0
+     * @access public
+     * @param object $query
+     * @return object $query
+     */
+
+    public function sensei_course_category_order_main_content($query) {
+        if ( is_tax() ) {
+            $query->set( 'orderby', 'menu_order' );
+            $query->set( 'order', 'ASC' );
+            return $query;
+        }
+    } // End sensei_course_category_order_main_content()
 
 } // End Class

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -1168,7 +1168,7 @@ class WooThemes_Sensei_Frontend {
 
     public function sensei_course_category_order_main_content($query) {
 
-        if ( is_tax() ) {
+        if ( is_tax('course-category') ) {
 
             $query->set( 'orderby', 'menu_order' );
             $query->set( 'order', 'ASC' );

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -111,6 +111,9 @@ class WooThemes_Sensei_Frontend {
 		// Fix pagination for course archive pages when filtering by course type
 		add_filter( 'pre_get_posts', array( $this, 'sensei_course_archive_pagination' ) );
 
+        // Sort the main query on custom taxonomy pages to pass posts in 'menu_order'
+        add_action('pre_get_posts', array ( $this, 'sensei_course_category_order_main_content' ) );
+
 		// Scripts and Styles
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'wp_head', array( $this, 'enqueue_scripts' ) );
@@ -149,7 +152,8 @@ class WooThemes_Sensei_Frontend {
 
 		// Hide Sensei activity comments from lesson and course pages
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
-	} // End __construct()
+
+    } // End __construct()
 
 	/**
 	 * Initialise the code.
@@ -1147,6 +1151,33 @@ class WooThemes_Sensei_Frontend {
 			$this->sensei_get_template_part( 'content', 'no-permissions' );
 		} // End While Loop
 	} // End sensei_no_permissions_main_content()
+
+
+    /**
+     * sensei_course_category_order_main_content function
+     *
+     * Sort the main query on custom taxonomy pages to pass posts in
+     * 'menu_order', because Sensei allows users to set the order of
+     * Courses under Course > Course Order.
+     *
+     * @since 1.9.0
+     * @access public
+     * @param object $query
+     * @return object $query
+     */
+
+    public function sensei_course_category_order_main_content($query) {
+
+        if ( is_tax() ) {
+
+            $query->set( 'orderby', 'menu_order' );
+            $query->set( 'order', 'ASC' );
+
+            return $query;
+
+        }
+
+    } // End sensei_course_category_order_main_content()
 
 	public function sensei_course_category_main_content() {
 		global $post;

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -1168,7 +1168,7 @@ class WooThemes_Sensei_Frontend {
 
     public function sensei_course_category_order_main_content($query) {
 
-        if ( is_tax('course-category') ) {
+        if ( is_tax() ) {
 
             $query->set( 'orderby', 'menu_order' );
             $query->set( 'order', 'ASC' );

--- a/includes/class-woothemes-sensei-frontend.php
+++ b/includes/class-woothemes-sensei-frontend.php
@@ -111,9 +111,6 @@ class WooThemes_Sensei_Frontend {
 		// Fix pagination for course archive pages when filtering by course type
 		add_filter( 'pre_get_posts', array( $this, 'sensei_course_archive_pagination' ) );
 
-        // Sort the main query on custom taxonomy pages to pass posts in 'menu_order'
-        add_action('pre_get_posts', array ( $this, 'sensei_course_category_order_main_content' ) );
-
 		// Scripts and Styles
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'wp_head', array( $this, 'enqueue_scripts' ) );
@@ -152,8 +149,7 @@ class WooThemes_Sensei_Frontend {
 
 		// Hide Sensei activity comments from lesson and course pages
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
-
-    } // End __construct()
+	} // End __construct()
 
 	/**
 	 * Initialise the code.
@@ -1151,33 +1147,6 @@ class WooThemes_Sensei_Frontend {
 			$this->sensei_get_template_part( 'content', 'no-permissions' );
 		} // End While Loop
 	} // End sensei_no_permissions_main_content()
-
-
-    /**
-     * sensei_course_category_order_main_content function
-     *
-     * Sort the main query on custom taxonomy pages to pass posts in
-     * 'menu_order', because Sensei allows users to set the order of
-     * Courses under Course > Course Order.
-     *
-     * @since 1.9.0
-     * @access public
-     * @param object $query
-     * @return object $query
-     */
-
-    public function sensei_course_category_order_main_content($query) {
-
-        if ( is_tax() ) {
-
-            $query->set( 'orderby', 'menu_order' );
-            $query->set( 'order', 'ASC' );
-
-            return $query;
-
-        }
-
-    } // End sensei_course_category_order_main_content()
 
 	public function sensei_course_category_main_content() {
 		global $post;


### PR DESCRIPTION
Fixes #1089. Not sure if there is a cleaner way to do this, but hooking into `pre_get_posts` seemed like the most straightforward solution here.