### PR TITLE
Refactored logic around products / settings and lesson access 

### DIFF
--- a/templates/content-single-lesson.php
+++ b/templates/content-single-lesson.php
@@ -32,7 +32,6 @@ $access_permission = false;
 
       $access_permission = true;
 
- // If 'Users must be logged in to view Course and Lesson content' is not turned off, ask the user to login.
  }
 
 ?>

--- a/templates/content-single-lesson.php
+++ b/templates/content-single-lesson.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         $is_product = false;
     }
 
+$access_permission = false;
+
  // If Settings > General > 'Users must be logged in to view Course and Lesson content' is turned off,
  // give logged out users full access.
   if ( isset( $woothemes_sensei->settings->settings['access_permission'] ) && ! $woothemes_sensei->settings->settings['access_permission']  || sensei_all_access() ) {
@@ -31,11 +33,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
       $access_permission = true;
 
  // If 'Users must be logged in to view Course and Lesson content' is not turned off, ask the user to login.
- } else {
+ }
 
-     $access_permission = false;
-
- } // End If Statement
 ?>
         	<article <?php post_class( array( 'lesson', 'post' ) ); ?>>
 


### PR DESCRIPTION
Fixes #1100. Separated our logic here into two parts, like we do in `content-single-course.php` -

https://github.com/woothemes/sensei/blob/master/templates/content-single-course.php#L21
https://github.com/woothemes/sensei/blob/master/templates/content-single-course.php#L55

Now, we:

1) Check whether lesson is attached to a WC product (`$is_product`)

2) Check whether global access setting allows logged out users to access Lesson content (`$access_permission`)

Use both these variables when granting / denying access.

Preliminary testing shows that the fix works, but it could use further testing / cleanup.