### PR TITLE
Added missing HTML to legacy shortcodes

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-loader.php
+++ b/includes/shortcodes/class-sensei-shortcode-loader.php
@@ -407,10 +407,15 @@ class Sensei_Shortcode_Loader{
                         ?>
                         <article class="<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $post_id ) ) ); ?>">
 
+                            <div class="course-content">
 
                             <?php Sensei()->course->course_image($post_id); ?>
 
-                            <?php echo $post_item->post_title; ?>
+                            <header>
+
+                            <h2><a href="<?php echo get_permalink($post_id) ?>" title="<?php echo $post_item->post_title; ?>"><?php echo $post_item->post_title; ?></a></h2>
+
+                            </header>
 
                             <section class="entry">
                                 <p class="sensei-course-meta">
@@ -430,17 +435,26 @@ class Sensei_Shortcode_Loader{
                                     <p class="sensei-free-lessons"><a href="<?php echo get_permalink( $post_id ); ?>"><?php _e( 'Preview this course', 'woothemes-sensei' ) ?></a> - <?php echo $preview_lessons; ?></p>
 
                                 <?php } ?>
-                            </section>
+                            </section></div>
+
+
+                            <footer></footer>
                         </article>
+
                     <?php
 
                     } // End For Loop
+
+
 
                     if ( '' != $shortcode_override && ( $amount <= count( $posts_array ) ) ) {
                         echo sensei_course_archive_next_link( $query_type );
                     } // End If Statement ?>
 
                 </section>
+
+
+
 
             <?php } // End If Statement
         } else {


### PR DESCRIPTION
Fixes #1123, though the HTML may need further tweaking. 

The Courses list output by these legacy shortcodes is still broken in Canvas: the 'View Course' button is not being output, but I didn't want to add it in the default Sensei legacy HTML here because some themes will not use it when listing Courses via shortcodes. 

It looks like Canvas may hook in somewhere there to output that button, and similarly, other themes may be using our old HTML structure as well, so we should make sure we keep using the exact same HTML we did till now.