### PR TITLE
Properly close the two div tags opened in the wrapper-main file

### DIFF
--- a/templates/globals/wrapper-end.php
+++ b/templates/globals/wrapper-end.php
@@ -12,5 +12,5 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  */
 ?>
 
-    </main>
+    </div>
 </div>


### PR DESCRIPTION
Changes the wrapper end to properly close the two `div` tags opened in the wrapper-start. Fixes #1260 