### PR TITLE
Typo fix in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.**
 
-Sensei is a commercial plugin available from http://www.woothemes.com/products/sensei/. The plugin is hosted here on a public Github repository in order to better faciliate community contributions from developers and users alike. If you have a suggestion, a bug report, or a patch for an issue, feel free to submit it here (following the guidelines below). We do ask, however, that if you are using the plugin on a live site that you please purchase a valid license from the website. We cannot provide support or one-click updates to anyone that does not hold a valid license key.
+Sensei is a commercial plugin available from http://www.woothemes.com/products/sensei/. The plugin is hosted here on a public Github repository in order to better facilitate community contributions from developers and users alike. If you have a suggestion, a bug report, or a patch for an issue, feel free to submit it here (following the guidelines below). We do ask, however, that if you are using the plugin on a live site that you please purchase a valid license from the website. We cannot provide support or one-click updates to anyone that does not hold a valid license key.
 
 # Architecture
 


### PR DESCRIPTION
The word `facilitate` is wrongly spelled as `faciliate`