### PR TITLE
bringing back the filter for WC purchase course button text

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -768,7 +768,16 @@ Class Sensei_WC{
 
             <button type="submit" class="single_add_to_cart_button button alt">
                 <?php $button_text = $product->get_price_html() . ' - ' . __( 'Purchase this Course', 'woothemes-sensei' ); ?>
-                <?php echo apply_filters( 'sensei_wc_single_add_to_cart_button_text', $button_text ); ?>
+                <?php
+                /**
+                 * Filter Add to Cart button text
+                 *
+                 * @since 1.9.1
+                 *
+                 * @param string $button_text
+                 */
+                echo apply_filters( 'sensei_wc_single_add_to_cart_button_text', $button_text );
+                ?>
             </button>
 
         </form>

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -767,7 +767,8 @@ Class Sensei_WC{
             <?php } ?>
 
             <button type="submit" class="single_add_to_cart_button button alt">
-                <?php echo $product->get_price_html(); ?> - <?php  _e('Purchase this Course', 'woothemes-sensei'); ?>
+                <?php $button_text = $product->get_price_html() . ' - ' . __( 'Purchase this Course', 'woothemes-sensei' ); ?>
+                <?php echo apply_filters( 'sensei_wc_single_add_to_cart_button_text', $button_text ); ?>
             </button>
 
         </form>


### PR DESCRIPTION
It is not always appropriate to have the price printed on the button. I have the price already printed next to the button in the theme I'm developing, so we need an option to change the button text. The filter was there before I gave it a name that is maybe more in the style of new changes.
